### PR TITLE
fix when location returns an address without scheme 

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -93,6 +93,9 @@ class TusClient {
       throw ProtocolException(
           "missing upload Uri in response for creating upload");
     }
+    if(urlStr.indexOf("//") == 0){
+      urlStr = "${url.scheme}:$urlStr";
+    }
 
     _uploadUrl = Uri.parse(urlStr);
     store?.set(_fingerprint, _uploadUrl);

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -71,7 +71,7 @@ class TusClient {
 
   /// Create a new [upload] throwing [ProtocolException] on server error
   create() async {
-    _fileSize = await file.length();
+    _fileSize = file.lengthSync();
 
     final client = getHttpClient();
     final createHeaders = Map<String, String>.from(headers ?? {})
@@ -104,7 +104,7 @@ class TusClient {
   /// Check if possible to resume an already started upload throwing
   ///  [FingerprintNotFoundException] or [ResumingNotEnabledException]
   resume() async {
-    _fileSize = await file.length();
+    _fileSize = file.lengthSync();
 
     if (!resumingEnabled) {
       throw ResumingNotEnabledException();


### PR DESCRIPTION
[https://github.com/tus/tus-node-server/pull/73](url)


using asynchrony in ios can cause errors in files that do not exist,  so i change 

```
    _fileSize = await file.length();//When the same file is uploaded multiple times, there may be a file error that does not exist

    _fileSize = file.lengthSync();//At present, I am not sure what the reason is. Please check it
```