### PR TITLE
Fixes retrieving of header field "Location" to satisfy protocol documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ build/
 coverage/
 coverage-html.sh
 tus_test.dart
+/.fvm/fvm_config.json
+/.fvm/flutter_sdk

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -160,7 +160,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -195,7 +195,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.2.19"
   tus_client:
     dependency: "direct main"
     description:

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -90,7 +90,7 @@ class TusClient {
           "unexpected status code (${response.statusCode}) while creating upload");
     }
 
-    String urlStr = response.headers["location"] ?? "";
+    String urlStr = response.headers["Location"] ?? "";
     if (urlStr.isEmpty) {
       throw ProtocolException(
           "missing upload Uri in response for creating upload");

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -365,7 +365,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -407,7 +407,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.2.19"
   timing:
     dependency: transitive
     description:

--- a/test/src/client_test.dart
+++ b/test/src/client_test.dart
@@ -82,7 +82,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async =>
-            http.Response("", 201, headers: {"location": uploadLocation}));
+            http.Response("", 201, headers: {"Location": uploadLocation}));
 
     await client.create();
 
@@ -99,7 +99,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 201, headers: {
-              "location":
+              "Location":
                   "//example.com/tus/1ae64b4f-bd7a-410b-893d-3614a4bd68a6"
             }));
 
@@ -118,7 +118,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 201, headers: {
-              "location": "/tus/1ae64b4f-bd7a-410b-893d-3614a4bd68a6"
+              "Location": "/tus/1ae64b4f-bd7a-410b-893d-3614a4bd68a6"
             }));
 
     await client.create();
@@ -136,7 +136,7 @@ main() {
     final client = MockTusClient(urlWithPort, file);
     when(client.httpClient?.post(urlWithPort, headers: anyNamed('headers')))
         .thenAnswer((_) async => http.Response("", 201, headers: {
-              "location": "/tus/1ae64b4f-bd7a-410b-893d-3614a4bd68a6"
+              "Location": "/tus/1ae64b4f-bd7a-410b-893d-3614a4bd68a6"
             }));
 
     await client.create();
@@ -154,7 +154,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 201,
-            headers: {"location": "$uploadLocation,$uploadLocation"}));
+            headers: {"Location": "$uploadLocation,$uploadLocation"}));
 
     await client.create();
 
@@ -170,7 +170,7 @@ main() {
   test('client_test.TusClient.create().failure.empty.location', () async {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
-        (_) async => http.Response("", 201, headers: {"location": ""}));
+        (_) async => http.Response("", 201, headers: {"Location": ""}));
 
     expectLater(
         () => client.create(),
@@ -219,7 +219,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async =>
-            http.Response("", 201, headers: {"location": uploadLocation}));
+            http.Response("", 201, headers: {"Location": uploadLocation}));
     when(client.httpClient?.head(any, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 200, headers: {"upload-offset": "0"}));
     when(client.httpClient?.patch(
@@ -260,7 +260,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async =>
-            http.Response("", 201, headers: {"location": uploadLocation}));
+            http.Response("", 201, headers: {"Location": uploadLocation}));
     when(client.httpClient?.head(any, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 200, headers: {"upload-offset": "0,0"}));
     when(client.httpClient?.patch(
@@ -301,7 +301,7 @@ main() {
     final client = MockTusClient(url, file, maxChunkSize: 50);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async =>
-            http.Response("", 201, headers: {"location": uploadLocation}));
+            http.Response("", 201, headers: {"Location": uploadLocation}));
     when(client.httpClient?.head(any, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 200, headers: {"upload-offset": "0"}));
     when(client.httpClient?.patch(
@@ -326,7 +326,7 @@ main() {
     final client = MockTusClient(url, file, maxChunkSize: 50);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async =>
-            http.Response("", 201, headers: {"location": uploadLocation}));
+            http.Response("", 201, headers: {"Location": uploadLocation}));
     when(client.httpClient?.head(any, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 200, headers: {"upload-offset": "0"}));
     int i = 0;
@@ -352,7 +352,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async =>
-            http.Response("", 201, headers: {"location": uploadLocation}));
+            http.Response("", 201, headers: {"Location": uploadLocation}));
     when(client.httpClient?.head(any, headers: anyNamed('headers')))
         .thenAnswer((_) async => http.Response("500 Server Error", 500));
 
@@ -368,7 +368,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async =>
-            http.Response("", 201, headers: {"location": uploadLocation}));
+            http.Response("", 201, headers: {"Location": uploadLocation}));
     when(client.httpClient?.head(any, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 204, headers: {"upload-offset": ""}));
     when(client.httpClient?.patch(any, headers: anyNamed('headers')))
@@ -387,7 +387,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async =>
-            http.Response("", 201, headers: {"location": uploadLocation}));
+            http.Response("", 201, headers: {"Location": uploadLocation}));
     when(client.httpClient?.head(any, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 204, headers: {"upload-offset": "0"}));
     when(client.httpClient?.patch(
@@ -408,7 +408,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async =>
-            http.Response("", 201, headers: {"location": uploadLocation}));
+            http.Response("", 201, headers: {"Location": uploadLocation}));
     when(client.httpClient?.head(any, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 204, headers: {"upload-offset": "0"}));
     when(client.httpClient?.patch(
@@ -429,7 +429,7 @@ main() {
     final client = MockTusClient(url, file);
     when(client.httpClient?.post(url, headers: anyNamed('headers'))).thenAnswer(
         (_) async =>
-            http.Response("", 201, headers: {"location": uploadLocation}));
+            http.Response("", 201, headers: {"Location": uploadLocation}));
     when(client.httpClient?.head(any, headers: anyNamed('headers'))).thenAnswer(
         (_) async => http.Response("", 204, headers: {"upload-offset": "0"}));
     when(client.httpClient?.patch(


### PR DESCRIPTION
@jjmutumi Greetings, I found a problem of discrepancy between the documentation of the TUS protocol and the implementation of this library, in the documentation the header field "Location" is written with the first letter in uppercase and in the library it is found with the first letter in lowercase, although it is an easy error to solve on the server side, it makes it difficult to implement this library on the frontend side.

[https://tus.io/protocols/resumable-upload.html#protocol-extensions](https://tus.io/protocols/resumable-upload.html#protocol-extensions)